### PR TITLE
Upgrade filebeat-oss from 7.11.1 to 7.12.1 (inode tracking bug fix)

### DIFF
--- a/.github/workflows/filebeat-docker-image.yml
+++ b/.github/workflows/filebeat-docker-image.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
 
 defaults:
   run:
@@ -31,7 +32,7 @@ jobs:
           push: true
           platforms: linux/arm64,linux/amd64
           file: diagnostics/opensearch/filebeat/Dockerfile
-          tags: duplocloud/filebeat-oss:7.11.1-${{ github.sha }}
+          tags: duplocloud/filebeat-oss:7.12.1-${{ github.sha }}
       - name: Build and push k8s docker image
         uses: docker/build-push-action@v4
         with:
@@ -39,4 +40,4 @@ jobs:
           push: true
           platforms: linux/arm64,linux/amd64
           file: diagnostics/opensearch/filebeat/Dockerfile-k8s
-          tags: duplocloud/filebeat-oss:7.11.1-${{ github.sha }}-k8s        
+          tags: duplocloud/filebeat-oss:7.12.1-${{ github.sha }}-k8s        

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Filebeat
 We use hints based autodiscover of filebeat to automatically discover the servicename and other labels. 
 With recent change of filebaet config. We now support Tenant level and Service level logs. Also these images are multi arch images can also be used with graviton instances.
-Native Linux Docker image: **duplocloud/filebeat-oss:7.11.1-00895c38db61c343a16ff9c02295dc096eb82db6**
+Native Linux Docker image: **duplocloud/filebeat-oss:7.12.1-$COMMIT_SHA**
 
-K8S image: **duplocloud/filebeat-oss:7.11.1-00895c38db61c343a16ff9c02295dc096eb82db6-k8s**
+K8S image: **duplocloud/filebeat-oss:7.12.1-$COMMIT_SHA-k8s**
 
 For **Tenant level logs**: Add the env varibale `"TENANT_LEVEL_INDEX": "yes"`  
 For the **Service level logs**: add the lables to the service.  

--- a/diagnostics/opensearch/filebeat/Dockerfile
+++ b/diagnostics/opensearch/filebeat/Dockerfile
@@ -1,8 +1,31 @@
-FROM duplocloud/filebeat-oss:7.11.1-r7
-USER root
-RUN apk update && apk upgrade
+FROM alpine:3.20
+
+ARG FILEBEAT_VERSION=7.12.1
+ARG TARGETARCH
+
+ENV PATH=$PATH:/usr/share/filebeat
+
+RUN apk add --no-cache bash su-exec libc6-compat curl &&\
+    apk add --no-cache -t .build-deps ca-certificates gnupg openssl &&\
+    set -ex &&\
+    if [ "$TARGETARCH" = "amd64" ]; then ARCH="x86_64"; else ARCH="$TARGETARCH"; fi &&\
+    wget -O /tmp/filebeat.tar.gz "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-oss-${FILEBEAT_VERSION}-linux-${ARCH}.tar.gz" &&\
+    mkdir -p /usr/share/filebeat &&\
+    tar -xzf /tmp/filebeat.tar.gz --strip-components=1 -C /usr/share/filebeat &&\
+    mkdir -p /usr/share/filebeat/logs /usr/share/filebeat/data &&\
+    adduser -DH -s /sbin/nologin filebeat &&\
+    chown -R filebeat:filebeat /usr/share/filebeat &&\
+    apk del --purge .build-deps &&\
+    rm -rf /tmp/* /var/cache/apk/*
+
+RUN apk update && apk upgrade && rm -rf /var/cache/apk/*
+
 COPY ./diagnostics/opensearch/filebeat/conf/filebeat.yml /usr/share/filebeat/filebeat.yml
 COPY ./diagnostics/opensearch/filebeat/filebeat-entrypoint.sh /filebeat-entrypoint.sh
 RUN chmod +x /filebeat-entrypoint.sh
 RUN chmod go-w /usr/share/filebeat/filebeat.yml
+
+WORKDIR /usr/share/filebeat
+ENTRYPOINT ["/filebeat-entrypoint.sh"]
+CMD ["-e", "-c", "/usr/share/filebeat/filebeat.yml"]
 USER filebeat

--- a/diagnostics/opensearch/filebeat/Dockerfile-k8s
+++ b/diagnostics/opensearch/filebeat/Dockerfile-k8s
@@ -1,8 +1,31 @@
-FROM duplocloud/filebeat-oss:7.11.1-r7-k8s
+FROM alpine:3.20
+
+ARG FILEBEAT_VERSION=7.12.1
+ARG TARGETARCH
+
+ENV PATH=$PATH:/usr/share/filebeat
+
+RUN apk add --no-cache bash su-exec libc6-compat curl &&\
+    apk add --no-cache -t .build-deps ca-certificates gnupg openssl &&\
+    set -ex &&\
+    if [ "$TARGETARCH" = "amd64" ]; then ARCH="x86_64"; else ARCH="$TARGETARCH"; fi &&\
+    wget -O /tmp/filebeat.tar.gz "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-oss-${FILEBEAT_VERSION}-linux-${ARCH}.tar.gz" &&\
+    mkdir -p /usr/share/filebeat &&\
+    tar -xzf /tmp/filebeat.tar.gz --strip-components=1 -C /usr/share/filebeat &&\
+    mkdir -p /usr/share/filebeat/logs /usr/share/filebeat/data &&\
+    adduser -DH -s /sbin/nologin filebeat &&\
+    chown -R filebeat:filebeat /usr/share/filebeat &&\
+    apk del --purge .build-deps &&\
+    rm -rf /tmp/* /var/cache/apk/*
+
+RUN apk update && apk upgrade && rm -rf /var/cache/apk/*
+
 COPY ./diagnostics/opensearch/filebeat/conf/filebeat-k8s.yml /usr/share/filebeat/filebeat.yml
 COPY ./diagnostics/opensearch/filebeat/filebeat-entrypoint.sh /filebeat-entrypoint.sh
-USER root
-RUN apk update && apk upgrade
 RUN chmod +x /filebeat-entrypoint.sh
 RUN chmod go-w /usr/share/filebeat/filebeat.yml
+
+WORKDIR /usr/share/filebeat
+ENTRYPOINT ["/filebeat-entrypoint.sh"]
+CMD ["-e", "-c", "/usr/share/filebeat/filebeat.yml"]
 USER filebeat

--- a/diagnostics/opensearch/filebeat/Dockerfile-k8s
+++ b/diagnostics/opensearch/filebeat/Dockerfile-k8s
@@ -20,6 +20,9 @@ RUN apk add --no-cache bash su-exec libc6-compat curl &&\
 
 RUN apk update && apk upgrade && rm -rf /var/cache/apk/*
 
+# Remove any default module configs that might interfere
+RUN rm -rf /usr/share/filebeat/modules.d/* /usr/share/filebeat/module
+
 COPY ./diagnostics/opensearch/filebeat/conf/filebeat-k8s.yml /usr/share/filebeat/filebeat.yml
 COPY ./diagnostics/opensearch/filebeat/filebeat-entrypoint.sh /filebeat-entrypoint.sh
 RUN chmod +x /filebeat-entrypoint.sh

--- a/diagnostics/opensearch/filebeat/buildAndPush.sh
+++ b/diagnostics/opensearch/filebeat/buildAndPush.sh
@@ -2,7 +2,7 @@
 revision=$1
 echo $revision
 
-docker buildx build --push --platform linux/arm64,linux/amd64 --tag duplocloud/filebeat-oss:7.11.1-${revision} .
+docker buildx build --push --platform linux/arm64,linux/amd64 --tag duplocloud/filebeat-oss:7.12.1-${revision} .
 
 
-docker buildx build --push --platform linux/arm64,linux/amd64 --tag duplocloud/filebeat-oss:7.11.1-${revision}-k8 --file Dockerfile-k8s .
+docker buildx build --push --platform linux/arm64,linux/amd64 --tag duplocloud/filebeat-oss:7.12.1-${revision}-k8 --file Dockerfile-k8s .

--- a/diagnostics/opensearch/filebeat/conf/filebeat-k8s.yml
+++ b/diagnostics/opensearch/filebeat/conf/filebeat-k8s.yml
@@ -12,10 +12,6 @@ filebeat.autodiscover:
           - /var/log/containers/*-${data.container.id}.log  # CRI path
         ignore_older: 24h
 processors:
-#Drop events from other namespaces except Duplo tenants.
-- drop_event:
-    when.not.regexp:
-      kubernetes.namespace: "^duploservices-*"
 - add_cloud_metadata: ~
 #Currently TENANT_NAME is not passed as ENV variable. Using labels to extract TENANT_NAME
 - copy_fields:

--- a/diagnostics/opensearch/filebeat/conf/filebeat-k8s.yml
+++ b/diagnostics/opensearch/filebeat/conf/filebeat-k8s.yml
@@ -1,3 +1,4 @@
+monitoring.enabled: false
 filebeat.autodiscover:
   providers:
     - type: kubernetes

--- a/diagnostics/opensearch/filebeat/conf/filebeat-k8s.yml
+++ b/diagnostics/opensearch/filebeat/conf/filebeat-k8s.yml
@@ -1,4 +1,7 @@
 monitoring.enabled: false
+http.enabled: false          
+logging.metrics.enabled: false  
+
 filebeat.autodiscover:
   providers:
     - type: kubernetes


### PR DESCRIPTION
## Description

Upgrades filebeat from 7.11.1 to 7.12.1 to resolve a known inode tracking bug during kubelet log rotation that causes harvesters to stop reading new log files ([elastic/beats#25002](https://github.com/elastic/beats/pull/25002)).

## Changes

- Replaced external base image `duplocloud/filebeat-oss:7.11.1-r7 > secureimages/filebeat-oss` with a self-contained Alpine 3.20 build that downloads filebeat-oss-7.12.1 directly from Elastic artifacts
- Multi-arch support (amd64/arm64) via TARGETARCH
- Added workflow_dispatch trigger to CI for manual builds from feature branches
- Updated version tags in `buildAndPush.sh`, GitHub Actions workflow, and `README`