### PR TITLE
Update Dockerfile-k8s

### DIFF
--- a/diagnostics/opensearch/filebeat/Dockerfile-k8s
+++ b/diagnostics/opensearch/filebeat/Dockerfile-k8s
@@ -20,6 +20,9 @@ RUN apk add --no-cache bash su-exec libc6-compat curl &&\
 
 RUN apk update && apk upgrade && rm -rf /var/cache/apk/*
 
+# Remove any default module configs that might interfere
+RUN rm -rf /usr/share/filebeat/modules.d/* /usr/share/filebeat/module
+
 COPY ./diagnostics/opensearch/filebeat/conf/filebeat-k8s.yml /usr/share/filebeat/filebeat.yml
 COPY ./diagnostics/opensearch/filebeat/filebeat-entrypoint.sh /filebeat-entrypoint.sh
 RUN chmod +x /filebeat-entrypoint.sh


### PR DESCRIPTION
Removed default module as we are using custom Kubernetes autodiscover

filebeat was existing with below error

`Exiting: error in autodiscover provider settings: error setting up docker autodiscover provider: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?`